### PR TITLE
Remove accept headers

### DIFF
--- a/docs/indexv2.html
+++ b/docs/indexv2.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf8">
+</head>
+
+<body>
+  <script src="https://api.apiary.io/seeds/embed.js"></script>
+  <script>
+    var embed = new Apiary.Embed({
+      subdomain: "metasysapiando",
+      preferences: {
+        permalinks: true,
+        displayHttpMethods: true
+      }
+    });
+  </script>
+</body>
+
+</html>

--- a/groups/alarms/alarms.apib
+++ b/groups/alarms/alarms.apib
@@ -29,11 +29,10 @@ Retrieves a collection of alarms.
     + sort (string, optional) - The criteria to use when sorting results (see [rules](#sorting-rules))
         + Accepted Values: `itemReference`, `priority`, `creationTime`
         + Default: `creationTime`
-    
+
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -52,18 +51,16 @@ Retrieves the specified alarm.
 + Request Analog Alarm
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
     + Headers
 
     + Attributes (AlarmEntityAnalog)
-    
+
 + Request Digital Alarm
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -100,7 +97,6 @@ Retrieves a collection of alarms for the specified network device.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -137,7 +133,6 @@ Retrieves a collection of alarms for the specified object.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)

--- a/groups/annotations/annotations.apib
+++ b/groups/annotations/annotations.apib
@@ -21,7 +21,6 @@ Retrieves the collection of annotations available for the specified alarm.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -47,7 +46,6 @@ Retrieves a collection of audit annotations.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)

--- a/groups/audits/audits.apib
+++ b/groups/audits/audits.apib
@@ -50,9 +50,6 @@ Retrieves the specified audit.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes(AuditEntity)
 

--- a/groups/audits/audits.apib
+++ b/groups/audits/audits.apib
@@ -29,7 +29,6 @@ Retrieves a collection of audits. When using multiple filters, an AND evaluation
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -48,7 +47,6 @@ Retrieves the specified audit.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -85,7 +83,6 @@ Retrieves a collection of audits for the specified object. When using multiple f
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)

--- a/groups/auth/auth.apib
+++ b/groups/auth/auth.apib
@@ -16,7 +16,6 @@ Used to login and retrieve an access token.
 
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
 
 
     + Attributes
@@ -37,7 +36,6 @@ Used to request a new access token prior to expiration.
 
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasys.v2+json)

--- a/groups/enums/enums.apib
+++ b/groups/enums/enums.apib
@@ -15,7 +15,6 @@ Retrieves a collection of all enumeration sets in the system.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -34,7 +33,6 @@ Retrieves the specified enumeration set.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -55,7 +53,6 @@ Retrieves the collection of member values belonging to the specified enumeration
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -75,7 +72,6 @@ Retrieves the specified enumeration member value.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)

--- a/groups/equipment/equipment.apib
+++ b/groups/equipment/equipment.apib
@@ -17,7 +17,6 @@ Retrieves a collection of equipment instances.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -36,7 +35,6 @@ Retrieves the specified equipment instance.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -60,7 +58,6 @@ Retrieves the equipment served by the specified equipment instance.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -86,13 +83,12 @@ Retrieves the collection of points that are defined by the specified equipment i
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
     + Headers
 
-    + Attributes 
+    + Attributes
         + Include EquipmentPointMappingCollection
         + self:`https://{hostname}/api/v2/equipment/{id}/points{?queryParams}` (string) - A link to this equipment point mapping collection
 
@@ -112,7 +108,6 @@ Retrieves the collection of equipment that serve the specified equipment instanc
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -138,7 +133,6 @@ Retrieves the collection of equipment instances that are hosted by the specified
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -164,7 +158,6 @@ Retrieves the collection of equipment that serve the specified space.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)

--- a/groups/network_devices/network_devices.apib
+++ b/groups/network_devices/network_devices.apib
@@ -21,7 +21,6 @@ Retrieves a collection of network devices.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -37,7 +36,6 @@ Retrieves the collection of all network device types.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -57,7 +55,6 @@ Retrieves the specified network device.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -81,7 +78,6 @@ Retrieves the collection of network devices that host the specified equipment in
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -107,7 +103,6 @@ Retrieves the collection of network devices that are children of the specified n
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -134,7 +129,6 @@ A space is considered to be served by a network device is considered to host an 
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)

--- a/groups/notifiers/notifiers.apib
+++ b/groups/notifiers/notifiers.apib
@@ -9,7 +9,6 @@ Retrieves list of all supported notifiers for server
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -59,7 +58,6 @@ Retrieves a collection of all supported notifiers for the specified network devi
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -109,7 +107,6 @@ Retrieves email notifier configuration for the server
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -123,7 +120,6 @@ Retrieves constraints for the email notifier configuration of the server
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -162,7 +158,6 @@ Update email notifier configuration for server.
 
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 204
@@ -198,7 +193,6 @@ Partially update email notifier configuration for server. User can edit  the `ss
 
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 204
@@ -215,7 +209,6 @@ Retrieves email notifier configuration for network device
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -229,7 +222,6 @@ Retrieves constraints for the email notifier configuration of the network device
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -268,7 +260,6 @@ Update email notifier configuration for network device.
 
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 204
@@ -304,7 +295,6 @@ Partially update email notifier configuration for network device. User can edit 
 
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 204
@@ -318,7 +308,6 @@ Retrieve email notifier destinations for server
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -437,7 +426,6 @@ Retrieve email notifier destinations for server
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -546,7 +534,6 @@ Retrieves constraints for the email notifier destination of the server.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -1044,7 +1031,6 @@ Add new email notifier destination for server
 
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 201 (application/vnd.metasysapi.v2+json)
@@ -1119,7 +1105,6 @@ Update email notifier single destination for server
 
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -1137,7 +1122,6 @@ Delete email notifier single destination for server
 
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 204 (application/vnd.metasysapi.v2+json)

--- a/groups/notifiers/notifiers.apib
+++ b/groups/notifiers/notifiers.apib
@@ -537,9 +537,6 @@ Retrieves constraints for the email notifier destination of the server.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes(EmailNotifierDestinationConstraintForServer)
 

--- a/groups/objects/objects.apib
+++ b/groups/objects/objects.apib
@@ -20,7 +20,6 @@ Retrieves a collection of objects. Note that this endpoint requires the `type` p
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -50,7 +49,6 @@ The object schema is used to validate the "object" content, opposed to entire pa
 + Request An Av with `?includeSchema=true`
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -199,7 +197,6 @@ The object schema is used to validate the "object" content, opposed to entire pa
 
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -241,7 +238,6 @@ The object schema is used to validate the "object" content, opposed to entire pa
 
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -400,7 +396,6 @@ The object schema is used to validate the "object" content, opposed to entire pa
 
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -456,7 +451,6 @@ Note: You must URL encode the Fully Qualified Reference in the query string.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (text/plain)
@@ -480,7 +474,6 @@ Retrieves the collection of objects that are children of the specified network d
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -506,7 +499,6 @@ Retrieves the children (recursively) of the specified object.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -536,7 +528,6 @@ will coordinate with the object to ensure the attribute is cached to make future
 + Request The presentValue of an AV Object
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -554,7 +545,6 @@ will coordinate with the object to ensure the attribute is cached to make future
 + Request The description of an object.
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -581,7 +571,6 @@ Retrieves all equipment points mapped to attributes of this object.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -605,7 +594,6 @@ Instead of using this action, use the send command action described below.
 
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
     + Body
@@ -623,7 +611,6 @@ Instead of using this action, use the send command action described below.
 
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
     + Body
@@ -649,7 +636,6 @@ get a list of commands for an object.
 + Request AV Example
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -810,7 +796,6 @@ get a list of commands for an object.
 + Request BV Example
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -983,7 +968,6 @@ get a list of commands for an object.
 + Request MV Example
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -1253,7 +1237,6 @@ Several error status codes are possible
     + Headers
 
             Authorization: Bearer [token]
-            Accept: application/vnd.metasysapi.v2+json
 
     + Body
 

--- a/groups/samples/samples.apib
+++ b/groups/samples/samples.apib
@@ -12,7 +12,6 @@ Retrieves a collection of attributes under the specified network device for whic
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -44,7 +43,6 @@ Note that the parent endpoint `https://{hostname}/api/v2/networkDevices/{id}/tre
 + Request Analog Samples
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -57,7 +55,6 @@ Note that the parent endpoint `https://{hostname}/api/v2/networkDevices/{id}/tre
 + Request Digital Samples
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -76,7 +73,6 @@ Retrieves a collection of attributes under the specified object for which sample
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -108,7 +104,6 @@ Note that the parent endpoint `https://{hostname}/api/v2/objects/{id}/trendedAtt
 + Request Analog Samples
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -121,7 +116,6 @@ Note that the parent endpoint `https://{hostname}/api/v2/objects/{id}/trendedAtt
 + Request Digital Samples
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)

--- a/groups/schemas/schemas.apib
+++ b/groups/schemas/schemas.apib
@@ -42,7 +42,6 @@ So to lookup the schema for the "Write Priority" enumeration, you would send a r
 + Request /schemas/enums/absentPresentEnumSet.schema.json
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)

--- a/groups/spaces/spaces.apib
+++ b/groups/spaces/spaces.apib
@@ -20,7 +20,6 @@ Retrieves a collection of spaces.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -39,7 +38,6 @@ Retrieves the specified space.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -63,7 +61,6 @@ Retrieves the collection of spaces served by the specified equipment instance.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -90,7 +87,6 @@ A space is considered to be served by a network device if any equipment instance
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)
@@ -116,7 +112,6 @@ Retrieves the collection of spaces that are located within the specified space.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)

--- a/groups/users/users.apib
+++ b/groups/users/users.apib
@@ -9,7 +9,6 @@ Retrieves user counts report information.
 + Request
     + Headers
 
-            Accept: application/vnd.metasysapi.v2+json
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v2+json)


### PR DESCRIPTION
We are removing the use of Accept headers for specifying a version. I also found one last remaining instance of Allow: Get

Finally I created an indexv2 page for previewing the 10.1 documentation