### PR TITLE
Remove Allow headers in 10.0 branch

### DIFF
--- a/groups/alarms/alarms.apib
+++ b/groups/alarms/alarms.apib
@@ -29,7 +29,7 @@ Retrieves a collection of alarms.
     + sort (string, optional) - The criteria to use when sorting results (see [rules](#sorting-rules))
         + Accepted Values: `itemReference`, `priority`, `creationTime`
         + Default: `creationTime`
-    
+
 + Request
     + Headers
 
@@ -37,9 +37,6 @@ Retrieves a collection of alarms.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include AlarmEntityCollection
@@ -58,12 +55,9 @@ Retrieves the specified alarm.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes (AlarmEntityAnalog)
-    
+
 + Request Digital Alarm
     + Headers
 
@@ -71,9 +65,6 @@ Retrieves the specified alarm.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes (AlarmEntityDigital)
 
@@ -110,9 +101,6 @@ Retrieves a collection of alarms for the specified network device.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes(NetworkDeviceAlarmsEntity)
 
@@ -149,8 +137,5 @@ Retrieves a collection of alarms for the specified object.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes (ObjectAlarmsEntity)

--- a/groups/annotations/annotations.apib
+++ b/groups/annotations/annotations.apib
@@ -25,9 +25,6 @@ Retrieves the collection of annotations available for the specified alarm.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include AlarmAnnotationEntityCollection
@@ -53,9 +50,6 @@ Retrieves a collection of audit annotations.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include AuditAnnotationEntityCollection

--- a/groups/audits/audits.apib
+++ b/groups/audits/audits.apib
@@ -33,9 +33,6 @@ Retrieves a collection of audits. When using multiple filters, an AND evaluation
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include AuditEntityCollection
@@ -46,7 +43,7 @@ Retrieves the specified audit.
 
 + Parameters
     + id:`00000000-0000-0000-0000-000000000000` (string) - The identifier of the audit to retrieve
-    
+
 + Request
     + Headers
 
@@ -54,9 +51,6 @@ Retrieves the specified audit.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes(AuditEntity)
 
@@ -91,9 +85,7 @@ Retrieves a collection of audits for the specified object. When using multiple f
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
 
-            Allow: GET
     + Attributes
         + Include AuditEntityCollection
         + self:`/objects/{id}/audits{?queryParams}` (string) - A link to this audit collection

--- a/groups/enums/enums.apib
+++ b/groups/enums/enums.apib
@@ -19,9 +19,6 @@ Retrieves a collection of all enumeration sets in the system.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include EnumSetCollection
@@ -40,9 +37,6 @@ Retrieves the specified enumeration set.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes(EnumSet)
 
@@ -63,9 +57,6 @@ Retrieves the collection of member values belonging to the specified enumeration
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include EnumMemberCollection
@@ -85,8 +76,5 @@ Retrieves the specified enumeration member value.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes(EnumMember)

--- a/groups/equipment/equipment.apib
+++ b/groups/equipment/equipment.apib
@@ -21,9 +21,6 @@ Retrieves a collection of equipment instances.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include EquipmentEntityCollection
@@ -42,9 +39,6 @@ Retrieves the specified equipment instance.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes (EquipmentEntity)
 
@@ -68,9 +62,6 @@ Retrieves the equipment served by the specified equipment instance.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include EquipmentEntityCollection
@@ -96,11 +87,8 @@ Retrieves the collection of points that are defined by the specified equipment i
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
 
-            Allow: GET
-
-    + Attributes 
+    + Attributes
         + Include EquipmentPointMappingCollection
         + self:`/equipment/{id}/points{?queryParams}` (string) - A link to this equipment point mapping collection
 
@@ -124,9 +112,6 @@ Retrieves the collection of equipment that serve the specified equipment instanc
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include EquipmentEntityCollection
@@ -152,9 +137,6 @@ Retrieves the collection of equipment instances that are hosted by the specified
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include EquipmentEntityCollection
@@ -180,9 +162,6 @@ Retrieves the collection of equipment that serve the specified space.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include EquipmentEntityCollection

--- a/groups/network_devices/network_devices.apib
+++ b/groups/network_devices/network_devices.apib
@@ -24,11 +24,8 @@ Retrieves a collection of network devices.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
 
-            Allow: GET
-
-    + Attributes 
+    + Attributes
         + Include NetworkDeviceEntityCollection
         + self:`/networkDevices{?queryParams}` (string) - A link to this network device collection
 
@@ -42,9 +39,6 @@ Retrieves the collection of all network device types.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include ItemCollection
@@ -64,9 +58,6 @@ Retrieves the specified network device.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes(NetworkDeviceEntity)
 
@@ -90,11 +81,8 @@ Retrieves the collection of network devices that host the specified equipment in
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
 
-            Allow: GET
-
-    + Attributes 
+    + Attributes
         + Include NetworkDeviceEntityCollection
         + self:`/equipment/{id}/networkDevices{?queryParams}` (string) - A link to this network device collection
 
@@ -118,11 +106,8 @@ Retrieves the collection of network devices that are children of the specified n
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
 
-            Allow: GET
-
-    + Attributes 
+    + Attributes
         + Include NetworkDeviceEntityCollection
         + self:`/networkDevices/{id}/networkDevices{?queryParams}` (string) - A link to this network device collection
 
@@ -147,9 +132,6 @@ A space is considered to be served by a network device is considered to host an 
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include NetworkDeviceEntityCollection

--- a/groups/objects/objects.apib
+++ b/groups/objects/objects.apib
@@ -24,9 +24,6 @@ Retrieves a collection of objects. Note that this endpoint requires the `type` p
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include ObjectEntityCollection
@@ -45,10 +42,6 @@ Retrieves the specified object.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-
-    + Headers
-
-            Allow: GET
 
     + Attributes(ObjectEntity)
 
@@ -72,11 +65,8 @@ Retrieves the collection of objects that are children of the specified network d
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
 
-            Allow: GET
-
-    + Attributes 
+    + Attributes
         + Include ObjectEntityCollection
         + self:`/networkDevices/{id}/objects{?queryParams}` (string) - A link to this object collection
 
@@ -100,10 +90,6 @@ Retrieves the children (recursively) of the specified object.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include ObjectEntityCollection
@@ -129,9 +115,6 @@ Retrieves all equipment points mapped to attributes of this object.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include EquipmentPointMappingCollection

--- a/groups/samples/samples.apib
+++ b/groups/samples/samples.apib
@@ -16,9 +16,6 @@ Retrieves a collection of attributes under the specified network device for whic
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include NetworkDeviceAttributeWithSamplesCollection
@@ -50,9 +47,6 @@ Note that the parent endpoint `/networkDevices/{id}/attributes/{attributeId}` is
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes(NetworkDeviceValueSamplesEntity)
       - items (array)
@@ -65,9 +59,6 @@ Note that the parent endpoint `/networkDevices/{id}/attributes/{attributeId}` is
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes (NetworkDeviceValueSamplesEntity)
       - items (array)
@@ -86,9 +77,6 @@ Retrieves a collection of attributes under the specified object for which sample
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include ObjectAttributeWithSamplesCollection
@@ -120,9 +108,6 @@ Note that the parent endpoint `/objects/{id}/attributes/{attributeId}` is not cu
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes (ObjectValueSamplesEntity)
       - items (array)
@@ -135,9 +120,6 @@ Note that the parent endpoint `/objects/{id}/attributes/{attributeId}` is not cu
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes (ObjectValueSamplesEntity)
       - items (array)

--- a/groups/spaces/spaces.apib
+++ b/groups/spaces/spaces.apib
@@ -24,9 +24,6 @@ Retrieves a collection of spaces.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include SpaceEntityCollection
@@ -45,9 +42,6 @@ Retrieves the specified space.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes (SpaceEntity)
 
@@ -71,9 +65,6 @@ Retrieves the collection of spaces served by the specified equipment instance.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include SpaceEntityCollection
@@ -100,9 +91,6 @@ A space is considered to be served by a network device if any equipment instance
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include SpaceEntityCollection
@@ -128,9 +116,6 @@ Retrieves the collection of spaces that are located within the specified space.
             Authorization: Bearer [token]
 
 + Response 200 (application/vnd.metasysapi.v1+json)
-    + Headers
-
-            Allow: GET
 
     + Attributes
         + Include SpaceEntityCollection


### PR DESCRIPTION
These were incorrectly used in 10.0 documentation and should
never have been there. While this has been corrected in 10.1
branch, master hasn't yet bet update til now.