### PR TITLE
Remove HOST metadata

### DIFF
--- a/_templates/header.apib
+++ b/_templates/header.apib
@@ -1,7 +1,5 @@
 FORMAT: 1A
 
-HOST: https://localhost/api/
-
 Metasys API
 ===========
 


### PR DESCRIPTION
I originally wanted to make sure that the version
number was included in each URL. When I realized that
each section just uses partial URLs I decided that was
probably cleaner, especially since there is no suitable
hostname for us to use.

So the ramification of this change is that each endpoint
will be defined with a partial URL. However, the very first
paragraphs of the API docs show how to construct a full URL
including version number.