### PR TITLE
Add HOST metadata back in

### DIFF
--- a/_templates/header.apib
+++ b/_templates/header.apib
@@ -1,5 +1,7 @@
 FORMAT: 1A
 
+HOST: https://example.com/api/v2
+
 Metasys API
 ===========
 


### PR DESCRIPTION
At first the removal of HOST worked well, but soon after Apiary seems to have substituted an auto-generated and very long hostname which makes the URLs almost unreadable. So adding this back in.

It currently looks like this:

<img width="837" alt="image" src="https://user-images.githubusercontent.com/824136/59215795-c7c20700-8b7f-11e9-860c-f7c7e496ce7f.png">
