### PR TITLE
Add discardedTime to audit response payload

### DIFF
--- a/groups/audits/audits_structs.apib
+++ b/groups/audits/audits_structs.apib
@@ -6,7 +6,8 @@
 + id:`00000000-0000-0000-0000-000000000000` (string) - The identifier of the audit
 + creationTime:`2017-09-18T08:11:28Z` (string) - The dateTime representing the creation time when this audit message was created
 + actionTypeUrl:`https://{hostname}/api/v2/enumSets/577/members/1` (string) - The action performed that initiated the audit. See https://{hostname}/api/v2/enumSets/577/members for possible values
-+ discarded (boolean) - Indicates if the audit has been discarded
++ discarded: (boolean) - Indicates if the audit has been discarded
++ discardedTime:`2017-09-18T08:11:28Z` (string, nullable) - The dateTime representing the discard time when this audit message was discarded
 + statusUrl:`https://{hostname}/api/v2/enumSets/516/members/1` (string) - Enumeration representing status. See https://{hostname}/api/v2/enumSets/516/members for possible values
 + preData (Data) - Data value prior to the Audit
 + postData (Data) - Data value after the Audit


### PR DESCRIPTION
This PR handles use case for knowing the discarded time of an audit without
having to make another API call for its annotations, the last being the
discard annotation.