### PR TITLE
Fix network device available types links

### DIFF
--- a/groups/network_devices/network_devices.apib
+++ b/groups/network_devices/network_devices.apib
@@ -41,7 +41,7 @@ Retrieves the collection of all network device types.
 
     + Attributes
         + Include ItemCollection
-        + items (array[ObjectTypeEnum], fixed-type)
+        + items (array[NetworkDeviceAvailableTypeLink], fixed-type)
         + self:`https://{hostname}/api/v2/networkDevices/availableTypes` - A link to this network device type collection
 
 ### Get A Single Network Device [GET /networkDevices/{id}]

--- a/groups/network_devices/network_devices_structs.apib
+++ b/groups/network_devices/network_devices_structs.apib
@@ -30,3 +30,6 @@
 + objectsUrl:`https://{hostname}/api/v2/networkDevices/{id}/objects` (string) - A link to the objects contained within this network device
 + trendedAttributesUrl:`https://{hostname}/api/v2/networkDevices/{id}/trendedAttributes` (string) - A link to the attributes on this network device for which samples are available
 + alarmsUrl:`https://{hostname}/api/v2/networkDevices/{id}/alarms` (string) - A link to the alarms available for this network device
+
+## NetworkDeviceAvailableTypeLink
++ typeUrl:`https://{hostname}/api/v2/enumSets/{id}/members/{memberId}` (string) - A link to the type of network device


### PR DESCRIPTION
The endpoint `/networkDevices/availableTypes` was returning `+ items
(array[ObjectTypeEnum], fixed-type)` as one of the returned attributes.
This is the wrong named declaration.

A `NetworkDeviceAvailableTypeLinks` named declaration has been added
which contains just a `typeUrl` to match the API response payload.
This will replace the `ObjectTypeEnum` named declaration previously
being returned.