### PR TITLE
Fix markdown markings, rendering

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,49 +4,50 @@
 
 Here are the changes to the API in release 10.1.
 
-### Added
-- Objects
-  - Lookup object ID
-  - Get a single object attribute
-  - Update an object
-  - Get commands for an object
-  - Send a command to an object<br><br>
-- Schemas
-  - Get a single enumeration schema
+### Added
 
-### Changed
+- Object
+  - Lookup object ID
+  - Get a single object attribute
+  - Update an object
+  - Get commands for an object
+  - Send a command to an object<br><br>
+- Schemas
+  - Get a single enumeration schema
 
-- Objects
-  - Added more information on the functionality of Get a single object.
-    - Added common object attributes to response payload.
-    - Included the 'schema' query parameter, which you can use to get optional schema in response payload.
-    - Changed response payload 'enumSet' links to enum values. **Note**: Breaking change.
-    - Changed 'attributes' link to 'trendedAttributesUrl'. **Note**: Breaking change.
+### Changed
 
-### Removed
+- Objects
+  - Added more information on the functionality of Get a single object.
+    - Added common object attributes to response payload.
+    - Included the 'schema' query parameter, which you can use to get optional schema in response payload.
+    - Changed response payload 'enumSet' links to enum values. **Note**: Breaking change.
+    - Changed 'attributes' link to 'trendedAttributesUrl'. **Note**: Breaking change.
 
-- Support for API version 1.
+### Removed
+
+- Support for API version 1.
 
 ## API documentation
 
 Here are the changes to the API documentation in release 10.1.
 
-## Changed
+## Changed
 
-- Introduction
-  - Added a base URL, this describes the base endpoint for the API.
-  - Removed the following details from API version notes:
-    - URL examples
-    - Accept header information
-    - Version specification rules
-  - Added an example for Version response behavior.
-  - Added DateTimes, which specifies that all date and time values in the document are ISO-8601 encoded.
-  - Added seven error descriptions to Validation:
-    - User not authenticated
-    - Record not authorized
-    - Identifier not found
-    - The resource already exists
-    - Internal server error
-    - The device is not supported
-    - The device is offline<br><br>
-  - Removed redirects. The client ceases to handle inbound and outbound HTTP calls; a reverse proxy now handles this operation.<br><br>
+- Introduction
+  - Added a base URL, this describes the base endpoint for the API.
+  - Removed the following details from API version notes:
+    - URL examples
+    - Accept header information
+    - Version specification rules
+  - Added an example for Version response behavior.
+  - Added DateTimes, which specifies that all date and time values in the document are ISO-8601 encoded.
+  - Added seven error descriptions to Validation:
+    - User not authenticated
+    - Record not authorized
+    - Identifier not found
+    - The resource already exists
+    - Internal server error
+    - The device is not supported
+    - The device is offline<br><br>
+  - Removed redirects. The client ceases to handle inbound and outbound HTTP calls; a reverse proxy now handles this operation.<br><br>

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,7 +6,7 @@ Here are the changes to the API in release 10.1.
 
 ### Added
 
-- Object
+- Objects
   - Lookup object ID
   - Get a single object attribute
   - Update an object


### PR DESCRIPTION
There were hiding markdown markings that prevented the markdown from
rendering properly. This pull request fixes the hidden markings.